### PR TITLE
Modernize build flags and iostream includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,12 @@
 # 
 # Use DESTDIR when installing to another prefix directory
 
-# Redhat 6.x
-CC	= g++
-CFLAGS  = -Wall -g -Wno-unused -DGTK_DISABLE_COMPAT_H #-pedantic  
-# no hace falta sacar la opcion -g porque uso 'install -s'
-#CFLAGS  = -Wall -Wno-unused -DGTK_DISABLE_COMPAT_H
-INCLUDE = `gtk-config --cflags`
-LIBS    = `gtk-config --libs`
+# Modern toolchain
+CC      = g++
+CFLAGS  = -Wall -g -Wno-unused -DGTK_DISABLE_COMPAT_H
+# Use pkg-config to obtain GTK flags
+INCLUDE = $(shell pkg-config --cflags gtk+-2.0)
+LIBS    = $(shell pkg-config --libs gtk+-2.0)
 DESTDIR  = /
 BINDIR  = ${DESTDIR}/usr/X11R6/bin
 

--- a/dialog.h
+++ b/dialog.h
@@ -28,7 +28,7 @@
 #ifndef _DIALOG_OSL_H_
 #define _DIALOG_OSL_H_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <gtk/gtk.h>
 #include <sys/types.h>

--- a/gpppkill.h
+++ b/gpppkill.h
@@ -28,7 +28,7 @@
 #ifndef	_GPPPKILL_HPP_OSL_
 #define _GPPPKILL_HPP_OSL_
 
-#include <iostream.h>
+#include <iostream>
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>

--- a/graf.cc
+++ b/graf.cc
@@ -416,12 +416,12 @@ void graf::dibujar(void)
 	double es, in;
 	es = escala;
 	in = incremento_escala;
-	cout << endl;
-	cout << "int  numero de lineas: " << (float)(escala/incremento_escala) << endl;
-	cout << "ceil numero de lineas: " << ceil(es/in) << endl;
-	cout << "int (separacion de lineas)  : " << altura_in << endl;
-	cout << "ceil(separacion de lineas)  : " << ceil((float)(gpppk->DRAW_ALTO / (es/in))) << endl;
-	cout << "ceil(separacion de lineas)  : " << ceil(gpppk->DRAW_ALTO / (es/in)) << endl;
+        std::cout << std::endl;
+        std::cout << "int  numero de lineas: " << (float)(escala/incremento_escala) << std::endl;
+        std::cout << "ceil numero de lineas: " << ceil(es/in) << std::endl;
+        std::cout << "int (separacion de lineas)  : " << altura_in << std::endl;
+        std::cout << "ceil(separacion de lineas)  : " << ceil((float)(gpppk->DRAW_ALTO / (es/in))) << std::endl;
+        std::cout << "ceil(separacion de lineas)  : " << ceil(gpppk->DRAW_ALTO / (es/in)) << std::endl;
 	//altura_in = (int)ceil((float)(gpppk->DRAW_ALTO / (es/in)));
 }*/
 	/*
@@ -660,7 +660,7 @@ gint graf_configure_event_callback(GtkWidget *widget, GdkEventConfigure *event, 
 				  														widget->allocation.height,
 				  														-1);
 		if(tmp_pix == NULL) {	//si no lo pude crear
-			cerr << "gpppkill_configure_event_callback: no hay memoria!" << endl;
+                        std::cerr << "gpppkill_configure_event_callback: no hay memoria!" << std::endl;
 			return FALSE;
 		}
 		grafico->pixmap =(GdkPixmap *)tmp_pix;	//guardar en graf::pixmap
@@ -680,7 +680,7 @@ gint graf_configure_event_callback(GtkWidget *widget, GdkEventConfigure *event, 
 				  														widget->allocation.height,
 				  														-1);
 			if(grafico->pix == NULL) {
-				cerr << "gpppkill_configure_event_callback(): no hay memoria!" << endl;
+                                std::cerr << "gpppkill_configure_event_callback(): no hay memoria!" << std::endl;
 				return FALSE;
 			}
 		}

--- a/graf.h
+++ b/graf.h
@@ -36,6 +36,9 @@
 #include "gpppkill_config.h"
 #include "gpppkill.h"
 
+extern "C" gint graf_expose_event_callback(GtkWidget *widget, GdkEventExpose *event, class graf *grafico);
+extern "C" gint graf_configure_event_callback(GtkWidget *widget, GdkEventConfigure *event, class graf *grafico);
+
 class graf {
 	private:
 		int x,							//posicion a dibujar la sigte barra

--- a/graf.h
+++ b/graf.h
@@ -28,7 +28,7 @@
 #ifndef _GRAF_OSL_H_
 #define _GRAF_OSL_H_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <gtk/gtk.h>
 #include <math.h>

--- a/listac.h
+++ b/listac.h
@@ -28,7 +28,7 @@
 #ifndef _LISTAC_OSL_HPP
 #define _LISTAC_OSL_HPP
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 
 /*

--- a/listadg.h
+++ b/listadg.h
@@ -28,7 +28,7 @@
 #ifndef _LISTADG_OSL_H_
 #define _LISTADG_OSL_H_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <string.h>
 

--- a/listadg.tmpl
+++ b/listadg.tmpl
@@ -42,7 +42,7 @@ template <class T> nododg<T>::nododg()
 	anterior=NULL;
 
 	if(DEBUG_LISTADG)
-		cout << "Constructor  nododg()\n";  	
+            std::cout << "Constructor  nododg()\n";
 }
 
 /*
@@ -51,7 +51,7 @@ template <class T> nododg<T>::nododg()
 template <class T> nododg<T>::~nododg()
 {
 	if(DEBUG_LISTADG) 
-		cout << "nododg borrado" << endl;
+            std::cout << "nododg borrado" << std::endl;
 }
 
 template <class T> nododg<T> nododg<T>::operator=(nododg<T> n)
@@ -77,7 +77,7 @@ template <class T> listadg<T>::listadg()
 	final=NULL;
 
 	if(DEBUG_LISTADG)
-		cout << "Constructor listadg()\n";
+            std::cout << "Constructor listadg()\n";
 }
 
 /*------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ template <class T> listadg<T>::~listadg()
 	borrar_listadg();
 
 	if(DEBUG_LISTADG)
-		cout << "Destructor listadg()\n";
+            std::cout << "Destructor listadg()\n";
 }
 
 //------------------------------------------------------------------------------

--- a/main.h
+++ b/main.h
@@ -28,7 +28,7 @@
 #ifndef	_MAIN_HPP_OSL_
 #define _MAIN_HPP_OSL_
 
-#include <iostream.h>
+#include <iostream>
 #include <gtk/gtk.h>
 
 #include "gpppkill_config.h"

--- a/messagebox.cc
+++ b/messagebox.cc
@@ -27,6 +27,10 @@
  */
 #include "messagebox.h"
 
+// Forward declarations for signal callbacks
+gint messagebox_clicked_callback(GtkButton *button, class messagebox *mbox);
+gint messagebox_delete_event_callback(GtkWidget *widget, GdkEventAny *event, class messagebox *mbox);
+
 messagebox::messagebox(char *str, class gpppkill	*g)
 {
 	cad = str;

--- a/messagebox.h
+++ b/messagebox.h
@@ -28,7 +28,7 @@
 #ifndef _MESSAGEBOX_OSL_H_
 #define _MESSAGEBOX_OSL_H_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <gtk/gtk.h>
 #include <sys/types.h>

--- a/pppkill.cc
+++ b/pppkill.cc
@@ -929,8 +929,8 @@ int pppkill::find_interface_pid(pid_t pid, char *iface)
 
 			fp = fopen(dir_entry->d_name, "r");
 			if(fp == NULL) {
-				cerr << "pppkill::find_interface_pid(): no se puede leer el archivo '" << dir_entry->d_name << "'" << endl;
-				cerr << "Esto se deberia poder hacer!" << endl;
+                                std::cerr << "pppkill::find_interface_pid(): no se puede leer el archivo '" << dir_entry->d_name << "'" << std::endl;
+                                std::cerr << "Esto se deberia poder hacer!" << std::endl;
 				exit(1);
 			}
 			fscanf(fp, "%d", &run_pid);

--- a/pppkill.cc
+++ b/pppkill.cc
@@ -320,7 +320,7 @@ int pppkill::cargar_lista_pppd(void)
 	pid_t pid_pppd;
   FILE 	  *fp_cmdline;
   DIR     *dp;
-  umode_t mode;
+  mode_t mode;
   struct dirent *dir_entry;
   struct stat   file_stat;
   pppd nuevo_ppp;
@@ -400,7 +400,7 @@ int pppkill::cargar_lista_chat(void)
 	pid_t pid_chat, ppid_chat;
   FILE 	  *fp_cmdline;
   DIR     *dp;
-  umode_t mode;
+  mode_t mode;
   struct dirent *dir_entry;
   struct stat   file_stat;
   chat nuevo_chat;

--- a/pppkill.h
+++ b/pppkill.h
@@ -35,7 +35,7 @@
 #define _PPPKILL_HPP_OSL_
 
 //ppp includes
-#include <iostream.h>
+#include <iostream>
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <sys/ioctl.h>

--- a/preferences.h
+++ b/preferences.h
@@ -28,7 +28,7 @@
 #ifndef	_PREFERENCES_HPP_OSL_
 #define _PREFERENCES_HPP_OSL_
 
-#include <iostream.h>
+#include <iostream>
 #include <gtk/gtk.h>
 
 #include "gpppkill_config.h"

--- a/preferences.h
+++ b/preferences.h
@@ -36,6 +36,22 @@
 
 #include "gpppkill.h"
 
+extern "C" gint preferences_ok_callback(GtkButton *button, class preferences *pref);
+extern "C" gint preferences_cancel_callback(GtkButton *button, class preferences *pref);
+extern "C" gint preferences_idletime_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_onlinetime_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_byte_in_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_byte_out_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_idletime_button_callback(GtkToggleButton *toggle_button, class preferences *pref);
+extern "C" gint preferences_onlinetime_button_callback(GtkToggleButton *toggle_button, class preferences *pref);
+extern "C" gint preferences_spinner_prefered_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_refresh_callback(GtkButton *button, class preferences *pref);
+extern "C" gint preferences_select_row_callback(GtkWidget *widget, gint row, gint column, GdkEventButton *event, class preferences *pref);
+extern "C" gint preferences_delete_event_callback(GtkWidget *widget, GdkEventAny *event, class preferences *pref);
+extern "C" gint preferences_button_option_warn_callback(GtkToggleButton *toggle_button, class preferences *pref);
+extern "C" gint preferences_spinner_warntime_callback(GtkEditable *editable, class preferences *pref);
+extern "C" gint preferences_button_warn_beep_callback(GtkToggleButton *toggle_button, class preferences *pref);
+
 //----------- class preferences --------------------
 class preferences : public dialog {
 	private:

--- a/rcfile.h
+++ b/rcfile.h
@@ -28,7 +28,7 @@
 #ifndef _RCFILE_HPP_OSL_
 #define _RCFILE_HPP_OSL_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/rcgpppkill.cc
+++ b/rcgpppkill.cc
@@ -378,7 +378,7 @@ int rcgpppkill::load_version(char *ver)
 	strcpy(ver, load_string_option("VERSION"));
 
 	if(ver[0] == '#') {
-		cout << "rcgpppkill::load_version(): no existe la entrada VERSION en ~/.gpppkillrc" << endl;
+                std::cout << "rcgpppkill::load_version(): no existe la entrada VERSION en ~/.gpppkillrc" << std::endl;
 		return 1;
 	}
 

--- a/rcgpppkill.h
+++ b/rcgpppkill.h
@@ -28,7 +28,7 @@
 #ifndef _GPPPKILLRC_HPP_OSL_
 #define _GPPPKILLRC_HPP_OSL_
 
-#include <iostream.h>
+#include <iostream>
 //para getuid() y getpwuid()
 #include <unistd.h>
 #include <pwd.h>

--- a/warning.cc
+++ b/warning.cc
@@ -26,6 +26,13 @@
  *  A copy of the GNU General Public License is included with this program.
  */
 #include "warning.h"
+
+// Forward declarations for signal callbacks
+gint warning_delete_event_callback(GtkWidget *widget, GdkEventAny *event, warning *w);
+gint warning_ok_callback(GtkButton *button, warning *w);
+gint warning_cancel_callback(GtkButton *button, warning *w);
+gboolean warning_key_callback(GtkWidget *widget, GdkEventKey *event, warning *w);
+gint warning_timeout_callback(gpointer w);
 // ############################# class warning #############################
 
 /*------------------------------------------------------------------------------
@@ -311,34 +318,35 @@ gboolean warning_key_callback(GtkWidget *widget, GdkEventKey *event, warning *w)
 
 /*------------------------------------------------------------------------------
  */
-gint warning_timeout_callback(warning *w)
+gint warning_timeout_callback(gpointer w)
 {
-	gfloat val;
-	int beep;
-  GtkAdjustment *adj;
+        warning *warn = static_cast<warning*>(w);
+        gfloat val;
+        int beep;
+        GtkAdjustment *adj;
 /*
 	static long tiempo = 0;
 	static char str[30];
 	
-	tiempo += w->intervalo;	//aumentar un intervalo mas hasta que sea multiplo de 1000, osea 1 seg.
+	tiempo += warn->intervalo;	//aumentar un intervalo mas hasta que sea multiplo de 1000, osea 1 seg.
 
 
 	g_print("timepo: %ld\n", tiempo);
 	if( !(tiempo%1000) ) {
-		sprintf(str, "seconds left: %d", ((w->tiempo_total)-(int)tiempo)/1000);
-		gtk_label_set(GTK_LABEL(w->label_time), str);
+		sprintf(str, "seconds left: %d", ((warn->tiempo_total)-(int)tiempo)/1000);
+		gtk_label_set(GTK_LABEL(warn->label_time), str);
 		gdk_beep();
 		//g_print("quedan: %d segundos\n", (w->tiempo_total)-(int)tiempo);
 	}
 */
 
-  adj = GTK_PROGRESS(w->pbar)->adjustment;
+  adj = GTK_PROGRESS(warn->pbar)->adjustment;
   val = adj->value;
-	//val = GTK_PROGRESS_BAR(w->pbar)->percentage;
+	//val = GTK_PROGRESS_BAR(warn->pbar)->percentage;
 	
 	//g_print("val: %f\n", val);
 
-	if(w->warn_beep) {
+	if(warn->warn_beep) {
 		//beep = (int)(val*WARNING_PBAR_PASOS);
 		beep = (int)(val);
 		beep++;
@@ -348,15 +356,15 @@ gint warning_timeout_callback(warning *w)
 	
 	//if(val < 1.0) {
 	if(val < adj->upper) {
-		//val += (w->incremento);
+                //val += (warn->incremento);
 		val++;
-		//gtk_progress_bar_update(GTK_PROGRESS_BAR(w->pbar), val);
-		gtk_progress_set_value (GTK_PROGRESS(w->pbar), val);
+		//gtk_progress_bar_update(GTK_PROGRESS_BAR(warn->pbar), val);
+		gtk_progress_set_value (GTK_PROGRESS(warn->pbar), val);
 		return TRUE;
 	}
 	else {
-		w->resultado = 1;
-		w->quit();
+		warn->resultado = 1;
+                warn->quit();
 		//return FALSE;	//remuevo el timeout
 		return TRUE;	//no remuevo el timeout
 	}

--- a/warning.h
+++ b/warning.h
@@ -28,7 +28,7 @@
 #ifndef _WARNING_OSL_H_
 #define _WARNING_OSL_H_
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h> // GDK_Escape
@@ -66,7 +66,7 @@ class warning : public dialog {
 		friend gint warning_ok_callback(GtkButton *button, warning *w);
 		friend gint warning_cancel_callback(GtkButton *button, warning *w);
 		friend gboolean warning_key_callback(GtkWidget *widget, GdkEventKey *event, warning *w);
-		friend gint warning_timeout_callback(warning *w);
+                friend gint warning_timeout_callback(gpointer w);
 
 	public:
 		warning(class gpppkill *g, int opcion);


### PR DESCRIPTION
## Summary
- modernize Makefile to use `pkg-config`
- replace deprecated `<iostream.h>` includes
- prefix remaining iostream usages with `std::`
- add forward declarations for signal callbacks

## Testing
- `apt-get install -y libgtk2.0-dev`
- `make` *(fails: ‘graf_expose_event_callback’ was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_683f791e097c8327b7c6c309d927c587