### PR TITLE
Add GTK compatibility layer and document build requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ CC	= g++
 CFLAGS  = -Wall -g -Wno-unused -DGTK_DISABLE_COMPAT_H #-pedantic  
 # no hace falta sacar la opcion -g porque uso 'install -s'
 #CFLAGS  = -Wall -Wno-unused -DGTK_DISABLE_COMPAT_H
-INCLUDE = $(shell pkg-config --cflags gtk+-3.0)
-LIBS    = $(shell pkg-config --libs gtk+-3.0)
+INCLUDE = $(shell pkg-config --cflags gtk+-2.0)
+LIBS    = $(shell pkg-config --libs gtk+-2.0)
 DESTDIR  = /
 BINDIR  = ${DESTDIR}/usr/X11R6/bin
 

--- a/README
+++ b/README
@@ -63,6 +63,13 @@ Install:
 - ------
 Please refer to the INSTALL file.
 
+Building on modern systems
+-------------------------
+This source tree uses legacy GTK 1/2 APIs (for example `GtkCList` and
+old progress bar widgets). Attempting to build with the GTK 4 stack on
+Ubuntu 24.04 fails because those APIs were removed. Significant porting
+work is required to migrate to a current toolkit.
+
 gpppkill Home Page:
 - -----------------
   http://www.pla.net.py/home/oliver/gpppkill/

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,20 @@
+#ifndef GPPPKILL_COMPAT_H
+#define GPPPKILL_COMPAT_H
+
+#include <gtk/gtk.h>
+
+#if GTK_MAJOR_VERSION < 3
+/* map GTK3 functions to GTK2 equivalents */
+static inline GtkWidget *gtk_box_new(GtkOrientation orientation, gint spacing) {
+    if (orientation == GTK_ORIENTATION_HORIZONTAL)
+        return gtk_hbox_new(FALSE, spacing);
+    else
+        return gtk_vbox_new(FALSE, spacing);
+}
+static inline GtkWidget *gtk_separator_new(GtkOrientation orientation) {
+    return (orientation == GTK_ORIENTATION_HORIZONTAL) ?
+        gtk_hseparator_new() : gtk_vseparator_new();
+}
+#endif
+
+#endif /* GPPPKILL_COMPAT_H */

--- a/dialog.h
+++ b/dialog.h
@@ -32,6 +32,7 @@
 using namespace std;
 #include <stdio.h>
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <sys/types.h>
 
 #include "gpppkill_config.h"

--- a/gpppkill.h
+++ b/gpppkill.h
@@ -31,6 +31,7 @@
 #include <iostream>
 using namespace std;
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/graf.h
+++ b/graf.h
@@ -32,6 +32,7 @@
 using namespace std;
 #include <stdio.h>
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <math.h>
 
 #include "gpppkill_config.h"

--- a/main.h
+++ b/main.h
@@ -31,6 +31,7 @@
 #include <iostream>
 using namespace std;
 #include <gtk/gtk.h>
+#include "compat.h"
 
 #include "gpppkill_config.h"
  

--- a/messagebox.h
+++ b/messagebox.h
@@ -32,6 +32,7 @@
 using namespace std;
 #include <stdio.h>
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <sys/types.h>
 
 #include "gpppkill_config.h"

--- a/pppkill.h
+++ b/pppkill.h
@@ -38,6 +38,7 @@
 #include <iostream>
 using namespace std;
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <string.h>

--- a/preferences.h
+++ b/preferences.h
@@ -31,6 +31,7 @@
 #include <iostream>
 using namespace std;
 #include <gtk/gtk.h>
+#include "compat.h"
 
 #include "gpppkill_config.h"
 #include "dialog.h"

--- a/warning.h
+++ b/warning.h
@@ -32,6 +32,7 @@
 using namespace std;
 #include <stdio.h>
 #include <gtk/gtk.h>
+#include "compat.h"
 #include <gdk/gdkkeysyms.h> // GDK_Escape
 #include <sys/types.h>
 


### PR DESCRIPTION
## Summary
- note build issues with modern GTK in README
- add a compatibility header for GTK2
- include the header across sources
- update Makefile to look for gtk+-2.0

## Testing
- `make` *(fails: undefined callbacks and deprecated GTK functions)*

------
https://chatgpt.com/codex/tasks/task_e_684068284e448327b28086f77c6fb631